### PR TITLE
updated flipping button to work in safari

### DIFF
--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -36,21 +36,18 @@ export default function Home() {
             default paragraph on the essay below.)
           </h1>
         </div>
-        <div className="column-span-5">
-          <div className={"button-container " + (ragged && "ragged")}>
-            <button
-              className="circle-button rag-on"
-              onClick={() => setRagging(true)}
-            >
-              Text currently unragged
-            </button>
-            <button
-              className="circle-button rag-off"
-              onClick={() => setRagging(false)}
-            >
-              Text currently ragged
-            </button>
-          </div>
+        <div className={"button-container " + (ragged ? "ragged" : "unragged")}>
+          <button
+            className="circle-button"
+            onClick={() => setRagging(!ragged)}
+          >
+            <svg viewBox="0 0 2 2">
+              <ellipse className="on-circle" rx="1" cx="1" ry="1" cy="1" />
+              <ellipse className="off-circle" rx="1" cx="1" ry="1" cy="1" />
+            </svg>
+            <span className="button-text on-text">Text currently ragged</span>
+            <span className="button-text off-text">Text currently unragged</span>
+          </button>
         </div>
       </section>
       <div className="minimal-hr" />

--- a/docs/styles/globals.scss
+++ b/docs/styles/globals.scss
@@ -1,6 +1,9 @@
 :root {
   --fg: #d1f0fd;
   --bg: #67645e;
+  --ease-in-cubic: cubic-bezier(0.32, 0, 0.67, 0);
+  --ease-out-cubic: cubic-bezier(0.33, 1, 0.68, 1);
+  --ease-cubic: cubic-bezier(0.65, 0, 0.35, 1);
 }
 html {
   font-size: 18px;
@@ -161,42 +164,76 @@ section {
 }
 
 /* Circle Button */
-.button-section {
-  height: 380px;
-}
-
 .button-container {
+  grid-column: span 2;
   position: relative;
-  width: 340px;
-  height: 340px;
-  transition: transform 0.5s ease-out;
-  perspective: 1px;
-  transform: rotateY(0deg);
-  transform-style: preserve-3d;
-  &.ragged {
-    transform: rotateY(180deg);
-  }
+  aspect-ratio: 1 / 1;
 }
 
 .circle-button {
   width: 100%;
   height: 100%;
-  border-radius: 300px;
-  border: 2px solid var(--fg);
   position: absolute;
   left: 0;
-  backface-visibility: hidden;
   font: inherit;
-  z-index: -10;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  border-radius: 50%;
+  --duration: 0.6s;
+  --duration-in: calc(var(--duration) / 3 * 2);
+  --duration-out: calc(var(--duration) / 3);
 
-  &.rag-on {
-    background: var(--fg);
-    color: var(--bg);
+  svg {
+    position: absolute;
+    inset: 0;
+    overflow: visible;
+    z-index: -1;
+    ellipse {
+      stroke: var(--fg);
+      stroke-width: 2px;
+      vector-effect: non-scaling-stroke;
+      rx: 0.001px;
+      opacity: 0;
+      transition: all var(--duration-out) var(--ease-in-cubic),
+        opacity var(--duration-out) step-end;
+      .ragged &.on-circle,
+      .unragged &.off-circle {
+        rx: 1px;
+        opacity: 1;
+        transition: all var(--duration-in) var(--ease-out-cubic), opacity 0s;
+        transition-delay: var(--duration-out);
+      }
+      &.on-circle {
+        fill: transparent;
+      }
+      &.off-circle {
+        fill: var(--fg);
+      }
+    }
   }
-  &.rag-off {
-    background: transparent;
-    color: var(--fg);
-    transform: rotateY(180deg);
+  .button-text {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all var(--duration-out) var(--ease-in-cubic);
+    transform: scaleX(0);
+    padding: 1rem;
+    .ragged &.on-text,
+    .unragged &.off-text {
+      transform: scaleX(1);
+      transition: all var(--duration-in) var(--ease-out-cubic);
+      transition-delay: var(--duration-out);
+    }
+    &.on-text {
+      color: var(--fg);
+    }
+    &.off-text {
+      color: var(--bg);
+    }
   }
 }
 
@@ -366,7 +403,12 @@ body:not(.mobile) .hover-title:hover + .hover-image {
   height: calc(100vh - 10rem);
 }
 
-@media (max-width: 800px) {
+@media (max-width: 1024px) {
+  .button-container {
+    grid-column: span 3 / -1;
+  }
+}
+@media (max-width: 840px) {
   .overview {
     font-size: 14pt;
     line-height: 16pt;
@@ -398,13 +440,9 @@ body:not(.mobile) .hover-title:hover + .hover-image {
 
   .button-section {
     position: center;
-    height: 400px;
   }
   .button-container {
-    text-align: center;
-    position: relative;
-    width: 255px;
-    height: 255px;
+    grid-column: span 3;
   }
 
   .exmaple {
@@ -427,6 +465,11 @@ body:not(.mobile) .hover-title:hover + .hover-image {
   .siteNav {
     grid-column: span 7;
     text-align: right;
+  }
+}
+@media (max-width: 640px) {
+  .button-container {
+    grid-column: span 4;
   }
 }
 


### PR DESCRIPTION
before

https://user-images.githubusercontent.com/1642599/144482656-990a8bd1-f89c-4eb5-b793-980658cdc63a.mov

after

https://user-images.githubusercontent.com/1642599/144482664-bfc16d02-04e6-49fa-96d5-377266330a7a.mov


freeze frame comparison
| before | after |
|-|-|
| ![Screen Shot 2021-12-02 at 13 36 09](https://user-images.githubusercontent.com/1642599/144482705-27958e12-11c5-4f63-b4c6-53ad1e7087f1.jpg) | ![Screen Shot 2021-12-02 at 13 36 54](https://user-images.githubusercontent.com/1642599/144482711-93a09bd2-b510-4d38-b0db-32cf5a2a5b18.jpg) |
| css transform rasterizes and lets the GPU mangle it | svg preserves a uniform stroke |

fixes #7