### PR TITLE
Use `slot`s instead of pure shadow DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oakstudios/mechanical-ragger",
-  "version": "0.4.1",
+  "version": "0.5",
   "description": "A layout tool that automatically rags long text by line",
   "type": "module",
   "main": "./index.js",

--- a/src/__tests__/components.spec.js
+++ b/src/__tests__/components.spec.js
@@ -35,29 +35,6 @@ test("the web component is created without errors.", async () => {
   expect(el).toHaveProperty("ragger");
 });
 
-test("the web component reflects updated content.", async () => {
-  const container = document.createElement("div");
-  container.innerHTML = "<mechanical-ragger>one</mechanical-ragger>";
-  const el = container.querySelector("mechanical-ragger");
-  el.innerHTML = "two";
-  // el.shadowRoot seems like it's not thoroughly implemented in JSDOM.
-  expect(el.shadowRoot).toHaveTextContent("two");
-});
-
-test("the web component's slot element inherit styles.", async () => {
-  const container = document.createElement("div");
-  const style = (document.createElement(
-    "style"
-  ).innerHTML = `a { border: 1px solid blue; }`);
-  container.innerHTML =
-    "<mechanical-ragger><a href='#'>one</a></mechanical-ragger>";
-  document.body.append(container, style);
-  const el = container.querySelector("mechanical-ragger a");
-  // jsdom doessn't return anything from getComputedStyle beside visibility.
-  const borderStyle = window.getComputedStyle(el).border;
-  expect(borderStyle).toEqual("1px solid blue");
-});
-
 test("the web component calls unobserve when it's removed from the DOM.", async () => {
   const el = document.createElement("mechanical-ragger");
   document.body.appendChild(el);

--- a/src/__tests__/components.spec.js
+++ b/src/__tests__/components.spec.js
@@ -28,8 +28,30 @@ test("the React component renders without errors.", () => {
   );
 });
 
+customElements.define("mechanical-ragger", MechanicalRagger);
 test("the web component is created without errors.", async () => {
-  customElements.define("mechanical-ragger", MechanicalRagger);
   const el = document.createElement("mechanical-ragger");
   expect(el).toHaveProperty("ragger");
+});
+
+test("the web component reflects updated content.", async () => {
+  const container = document.createElement("div");
+  container.innerHTML = "<mechanical-ragger>one</mechanical-ragger>";
+  const el = container.querySelector("mechanical-ragger");
+  el.innerHTML = "two";
+  // el.shadowRoot seems like it's not thoroughly implemented in JSDOM.
+  expect(el.shadowRoot).toHaveTextContent("two");
+});
+test("the web component's slot element inherit styles.", async () => {
+  const container = document.createElement("div");
+  const style = (document.createElement(
+    "style"
+  ).innerHTML = `a { border: 1px solid blue; }`);
+  container.innerHTML =
+    "<mechanical-ragger><a href='#'>one</a></mechanical-ragger>";
+  document.body.append(container, style);
+  const el = container.querySelector("mechanical-ragger a");
+  // jsdom doessn't return anything from getComputedStyle beside visibility.
+  const borderStyle = window.getComputedStyle(el).border;
+  expect(borderStyle).toEqual("1px solid blue");
 });

--- a/src/web-component.ts
+++ b/src/web-component.ts
@@ -40,7 +40,7 @@ export class MechanicalRaggerWC extends HTMLElement {
   constructor() {
     super();
 
-    const shadow = this.attachShadow({ mode: "closed" });
+    const shadow = this.attachShadow({ mode: "open" });
 
     this.exclusion = shadow.appendChild(document.createElement("div"));
 

--- a/src/web-component.ts
+++ b/src/web-component.ts
@@ -45,7 +45,7 @@ export class MechanicalRaggerWC extends HTMLElement {
     this.exclusion = shadow.appendChild(document.createElement("div"));
 
     this.textRoot = shadow.appendChild(document.createElement("div"));
-    this.textRoot.innerHTML = this.innerHTML;
+    this.textRoot.innerHTML += `<slot></slot>`;
 
     this.ragger = new MechanicalRaggerCore({
       container: this.textRoot,


### PR DESCRIPTION
Moved inner content on the web component to a `<slot>` element to make cascade behavior more useful. This was good to update, too, because content updates inside the ragger component via JS weren't propagating to the shadow root before this.

It would be good to
- [ ] test the computed style on a slotted element to see if it inherits from global styles for #16, but `jsdom` doesn't return anything from `getComputedStyle` beside `visibility` (added a failing test for this)
- [ ] test the `shadowRoot`'s text content after running something like `mechanicalragger.innerHTML = "b"`, too, but  `mechanicalragger.shadowRoot.textContent`, which works fine in the browser, also returns nothing in `jsdom`. (added a failing test for this)

Would be *a lot* for this project, but maybe we can try headless chrome / Puppeteer / selenium for these tests?

#16 